### PR TITLE
use build ol_artifacts.repo for newer golang to fix Go advisories

### DIFF
--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,6 +9,10 @@ version="{{{ .major }}}.{{{ .minor }}}.{{{ .patch }}}"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}
 
+if [ -f "/etc/yum.repos.internal.d/ol_artifacts.repo" ]; then
+    cp /etc/yum.repos.internal.d/ol_artifacts.repo ./
+fi
+
 "${CONTAINER_CLI}" build --pull \
     --build-arg https_proxy=${https_proxy} \
     --build-arg version=${version} \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,11 +9,13 @@ version="{{{ .major }}}.{{{ .minor }}}.{{{ .patch }}}"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}
 
-if [ -f "/etc/yum.repos.internal.d/ol_artifacts.repo" ]; then
-    cp /etc/yum.repos.internal.d/ol_artifacts.repo ./
-fi
+args=(--build-arg https_proxy=${https_proxy}
+        --build-arg version=${version})
 
-"${CONTAINER_CLI}" build --pull \
-    --build-arg https_proxy=${https_proxy} \
-    --build-arg version=${version} \
-    -t ${docker_tag} -f ./olm/builds/Dockerfile .
+[[ -f /etc/yum.repos.internal.d/ol_artifacts.repo ]] && \
+        args+=(--volume /etc/yum.repos.internal.d/ol_artifacts.repo:/etc/yum.repos.internal.d/ol_artifacts.re
+[[ -f /etc/yum.conf ]] && args+=(--volume /etc/yum.conf:/etc/yum.conf)
+
+args+=(-t ${docker_tag} -f ./olm/builds/Dockerfile .)
+
+"${CONTAINER_CLI}" build --pull "${args[@]}"

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,7 +1,9 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
+COPY ol_artifacts.repo /etc/yum.repos.d/
+
 RUN dnf config-manager --enable ol9_codeready_builder && \
-    dnf update -y && dnf install -y golang patch
+    dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch
 
 WORKDIR /ceph-csi-operator
 COPY . .

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,9 +1,9 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
-COPY ol_artifacts.repo /etc/yum.repos.d/
+ARG DNF_GOLANG_ARG=""
 
 RUN dnf config-manager --enable ol9_codeready_builder && \
-    dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch
+    dnf update -y && dnf install "${DNF_GOLANG_ARG}" -y golang patch
 
 WORKDIR /ceph-csi-operator
 COPY . .


### PR DESCRIPTION
use build ol_artifacts.repo for newer golang to fix Go advisories