### PR TITLE
use build ol_artifacts.repo for newer golang to fix Go advisories

### DIFF
--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,6 +9,10 @@ version="0.4.0"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
+if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
+    cp /etc/yum.repos.d/ol_artifacts.repo ./
+fi
+
 "${CONTAINER_CLI}" build --pull \
     --build-arg https_proxy=${https_proxy} \
     --build-arg version=${version} \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,7 +9,7 @@ version="0.4.0"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
-ls lh "/etc/yum.repos.d/"
+ls -lh "/etc/yum.repos.d/"
 if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
     cat /etc/yum.repos.d/ol_artifacts.repo
     cp /etc/yum.repos.d/ol_artifacts.repo ./

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -10,6 +10,7 @@ registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
 ls -lh "/etc/yum.repos.d/"
+grep "incubator" -r "/etc/yum.repos.d/"
 if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
     cp /etc/yum.repos.d/ol_artifacts.repo ./
     cat ol_artifacts.repo

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -10,6 +10,7 @@ registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
 if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
+    cat /etc/yum.repos.d/ol_artifacts.repo
     cp /etc/yum.repos.d/ol_artifacts.repo ./
 fi
 

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -11,8 +11,8 @@ docker_tag=${registry}/${name}:v${version}-1
 
 ls -lh "/etc/yum.repos.d/"
 if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
-    cat /etc/yum.repos.d/ol_artifacts.repo
     cp /etc/yum.repos.d/ol_artifacts.repo ./
+    cat ol_artifacts.repo
 fi
 
 "${CONTAINER_CLI}" build --pull \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -7,7 +7,7 @@ CONTAINER_CLI="${CONTAINER_CLI:-podman}"
 name="ceph-csi-operator"
 version="0.4.0"
 registry="container-registry.oracle.com/olcne"
-docker_tag=${registry}/${name}:v${version}
+docker_tag=${registry}/${name}:v${version}-1
 
 "${CONTAINER_CLI}" build --pull \
     --build-arg https_proxy=${https_proxy} \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,6 +9,7 @@ version="0.4.0"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
+ls lh "/etc/yum.repos.d/"
 if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
     cat /etc/yum.repos.d/ol_artifacts.repo
     cp /etc/yum.repos.d/ol_artifacts.repo ./

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -10,19 +10,13 @@ registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
 dnf repolist --enabled -v
-ls -lh "/etc/yum.repos.d/"
-grep "incubator" -r "/etc/yum.repos.d/"
-if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
-    cp /etc/yum.repos.d/ol_artifacts.repo ./
+ls -lh "/etc/yum.repos.internal.d/"
+grep "incubator" -r "/etc/yum.repos.internal.d/"
+if [ -f "/etc/yum.repos.internal.d/ol_artifacts.repo" ]; then
+    cp /etc/yum.repos.internal.d/ol_artifacts.repo ./
     cat ol_artifacts.repo
 fi
 
-ls -lh "/etc/yum-repos-shared/"
-if [ -f "/etc/yum-repos-shared/ol_artifacts.repo" ]; then
-    cp /etc/yum-repos-shared/ol_artifacts.repo ./
-    cat ol_artifacts.repo
-fi
-ls -lh "/etc/yum*/"
 "${CONTAINER_CLI}" build --pull \
     --build-arg https_proxy=${https_proxy} \
     --build-arg version=${version} \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,6 +9,7 @@ version="0.4.0"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
+dnf repolist --enabled -v
 ls -lh "/etc/yum.repos.d/"
 grep "incubator" -r "/etc/yum.repos.d/"
 if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -15,6 +15,12 @@ if [ -f "/etc/yum.repos.d/ol_artifacts.repo" ]; then
     cat ol_artifacts.repo
 fi
 
+ls -lh "/etc/yum-repos-shared/"
+if [ -f "/etc/yum-repos-shared/ol_artifacts.repo" ]; then
+    cp /etc/yum-repos-shared/ol_artifacts.repo ./
+    cat ol_artifacts.repo
+fi
+ls -lh "/etc/yum*/"
 "${CONTAINER_CLI}" build --pull \
     --build-arg https_proxy=${https_proxy} \
     --build-arg version=${version} \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,12 +9,8 @@ version="0.4.0"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
-dnf repolist --enabled -v
-ls -lh "/etc/yum.repos.internal.d/"
-grep "incubator" -r "/etc/yum.repos.internal.d/"
 if [ -f "/etc/yum.repos.internal.d/ol_artifacts.repo" ]; then
     cp /etc/yum.repos.internal.d/ol_artifacts.repo ./
-    cat ol_artifacts.repo
 fi
 
 "${CONTAINER_CLI}" build --pull \

--- a/olm/build-image.sh
+++ b/olm/build-image.sh
@@ -9,11 +9,13 @@ version="0.4.0"
 registry="container-registry.oracle.com/olcne"
 docker_tag=${registry}/${name}:v${version}-1
 
-if [ -f "/etc/yum.repos.internal.d/ol_artifacts.repo" ]; then
-    cp /etc/yum.repos.internal.d/ol_artifacts.repo ./
-fi
+args=(--build-arg https_proxy=${https_proxy}
+	--build-arg version=${version})
 
-"${CONTAINER_CLI}" build --pull \
-    --build-arg https_proxy=${https_proxy} \
-    --build-arg version=${version} \
-    -t ${docker_tag} -f ./olm/builds/Dockerfile .
+[[ -f /etc/yum.repos.internal.d/ol_artifacts.repo ]] && \
+	args+=(--volume /etc/yum.repos.internal.d/ol_artifacts.repo:/etc/yum.repos.internal.d/ol_artifacts.repo --build-arg DNF_GOLANG_ARG="--setopt=ol9_appstream.exclude=golang")
+[[ -f /etc/yum.conf ]] && args+=(--volume /etc/yum.conf:/etc/yum.conf)
+
+args+=(-t ${docker_tag} -f ./olm/builds/Dockerfile .)
+
+"${CONTAINER_CLI}" build --pull "${args[@]}"

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,6 +1,6 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
-COPY *.repo /etc/yum.repos.d/
+COPY ol_artifacts.repo /etc/yum.repos.d/
 RUN dnf repolist enabled 
 RUN dnf repolist disabled 
 

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,7 +1,9 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
+COPY *.repo /etc/yum.repos.d/
+
 RUN dnf config-manager --enable ol9_codeready_builder && \
-    dnf update -y && dnf install -y golang patch
+    dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch
 
 WORKDIR /ceph-csi-operator
 COPY . .

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,9 +1,9 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
-COPY ol_artifacts.repo /etc/yum.repos.d/
+ARG DNF_GOLANG_ARG=""
 
 RUN dnf config-manager --enable ol9_codeready_builder && \
-    dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch
+    dnf update -y && dnf install "${DNF_GOLANG_ARG}" -y golang patch
 
 WORKDIR /ceph-csi-operator
 COPY . .

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,6 +1,7 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
 COPY ol_artifacts.repo /etc/yum.repos.d/
+RUN cat /etc/yum.repos.d/ol_artifacts.repo
 RUN dnf repolist enabled 
 RUN dnf repolist disabled 
 

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,6 +1,7 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
 COPY *.repo /etc/yum.repos.d/
+RUN dnf repolist
 
 RUN dnf config-manager --enable ol9_codeready_builder && \
     dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,9 +1,6 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
 COPY ol_artifacts.repo /etc/yum.repos.d/
-RUN cat /etc/yum.repos.d/ol_artifacts.repo
-RUN dnf repolist enabled 
-RUN dnf repolist disabled 
 
 RUN dnf config-manager --enable ol9_codeready_builder && \
     dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch

--- a/olm/builds/Dockerfile
+++ b/olm/builds/Dockerfile
@@ -1,7 +1,8 @@
 FROM container-registry.oracle.com/os/oraclelinux:9 AS builder
 
 COPY *.repo /etc/yum.repos.d/
-RUN dnf repolist
+RUN dnf repolist enabled 
+RUN dnf repolist disabled 
 
 RUN dnf config-manager --enable ol9_codeready_builder && \
     dnf update -y && dnf install --setopt=ol9_appstream.exclude=golang -y golang patch

--- a/olm/jenkins/ci/Jenkinsfile
+++ b/olm/jenkins/ci/Jenkinsfile
@@ -2,7 +2,7 @@
 import com.oracle.olcne.pipeline.BranchPattern
 
 String version = "0.4.0"
-String imageTag = 'v' + version
+String imageTag = 'v' + version + "-1"
 
 imagePipeline(
         branchPattern: new BranchPattern(master: 'oracle/release/0.4.0', feature: '(?!^release/.*$)(^.*$)'),


### PR DESCRIPTION
use build ol_artifacts.repo for newer golang to fix Go advisories

## Container Images
- container-registry.oracle.com/olcne/ceph-csi-operator:v0.4.0-1